### PR TITLE
Fixed css minification

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('css', function() {
   return gulp.src('css/app.scss')
   .pipe(sourcemaps.init())
   .pipe(sass({
-    style: 'compressed',
+    outputStyle: 'compressed',
     includePaths: [config.bowerDir + '/bootstrap-sass/assets/stylesheets'],
   }))
   .pipe(sourcemaps.write())


### PR DESCRIPTION
Thanks for your example, it helped me a lot!

As per `gulp-sass` documentation, `outputStyle` is the right parameter for compression.

Source: https://github.com/dlmanning/gulp-sass#options
